### PR TITLE
added plank recipes that don't need a saw to minecolonies sawmill

### DIFF
--- a/kubejs/data/minecolonies/crafterrecipes/sawmill/planks.json
+++ b/kubejs/data/minecolonies/crafterrecipes/sawmill/planks.json
@@ -1,0 +1,23 @@
+{
+  "type": "recipe-template",
+  "tag": "minecraft:logs",
+  "filter": {
+    "include": [ "_log" ],
+    "exclude": [ "stripped_" ]
+  },
+  "recipe": {
+    "crafter": "sawmill_crafting",
+    "inputs": [
+      {
+        "item": "[NS]:stripped_[PATH]"
+      }
+    ],
+    "alternate-output": [
+      {
+        "item": "[NS]:[PATH:_log=_planks]",
+		"count": 4
+      }
+    ],
+    "intermediate": "minecraft:air"
+  }
+}


### PR DESCRIPTION
The default recipe (saw + stripped log) doesn't work correctly for minecolonies.

As a workaround I've added recipes for all planks which don't require any saw to the sawmill.

One downside is that at lower levels of the building new recipes can't be added without deleting the plank recipes, as the amount of learned recipes exceeds the maximum allowed.
In my opinion, as long as there is no better solution, this is a worthwhile tradeoff though.